### PR TITLE
Add highlight agent for clicks column

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -6,5 +6,22 @@ export const agents: Record<string, AgentFunction | undefined> = {
    */
   sample: (webview) => {
     webview.executeJavaScript(`document.body.style.backgroundColor = 'lightyellow'; alert('Agent executed');`);
+  },
+  /**
+   * Highlight the clicks column with a green border and background.
+   */
+  highlightClicks: (webview) => {
+    const js = `(() => {
+      const style = document.createElement('style');
+      style.textContent = 
+        'td[style*="coldp-clicks"] .pr-cell a.pr-link {' +
+        ' border: 1px solid #0a0;' +
+        ' background-color: #b6ffb6;' +
+        ' border-radius: 4px;' +
+        ' padding: 2px 4px;' +
+        '}';
+      document.head.appendChild(style);
+    })();`;
+    webview.executeJavaScript(js);
   }
 };


### PR DESCRIPTION
## Summary
- introduce `highlightClicks` agent to highlight Clicks cells with green border and background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846594ba8c883258eaa6228db34bd95