### PR TITLE
Improve image highlighting

### DIFF
--- a/__tests__/agents.test.ts
+++ b/__tests__/agents.test.ts
@@ -8,17 +8,27 @@ describe('agents', () => {
     expect(typeof agents.sample).toBe('function');
   });
 
-  test('highlightImages adds style to document', () => {
+  test('highlightImages adds style to document and iframe', () => {
     const html = fs.readFileSync(path.join(__dirname, 'fixtures/sample.html'), 'utf8');
     const dom = new JSDOM(html, { runScripts: 'dangerously' });
+
+    // Attach a DOM to the iframe for testing
+    const iframe = dom.window.document.getElementById('inner-frame') as HTMLIFrameElement;
+    const inner = new JSDOM('<html><body><img id="fimg"></body></html>', { runScripts: 'dangerously' });
+    Object.defineProperty(iframe, 'contentDocument', { value: inner.window.document });
+
     const webview = {
       executeJavaScript: (code: string) => {
         const vm = require('vm');
         vm.runInContext(code, dom.getInternalVMContext());
       }
     } as any;
+
     agents.highlightImages!(webview);
     const style = dom.window.document.head.querySelector('style');
     expect(style?.textContent).toContain('img');
+
+    const iframeStyle = inner.window.document.head.querySelector('style');
+    expect(iframeStyle?.textContent).toContain('img');
   });
 });

--- a/__tests__/fixtures/sample.html
+++ b/__tests__/fixtures/sample.html
@@ -5,6 +5,7 @@
 </head>
 <body>
   <img src="test.jpg" id="test-image">
+  <iframe id="inner-frame" srcdoc="<img src='inner.jpg' id='inner-image'>"></iframe>
   <table>
     <tbody>
       <tr>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tg-ads-extension",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tg-ads-extension",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "electron": "^36.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tg-ads-extension",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "dist/main.js",
   "scripts": {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -29,9 +29,22 @@ export const agents: Record<string, AgentFunction | undefined> = {
    */
   highlightImages: (webview) => {
     const js = `(() => {
-      const style = document.createElement('style');
-      style.textContent = 'img { outline: 2px solid red; }';
-      document.head.appendChild(style);
+      const addStyle = (doc) => {
+        const style = doc.createElement('style');
+        style.textContent = 'img { outline: 2px solid red; }';
+        doc.head.appendChild(style);
+      };
+      addStyle(document);
+      document.querySelectorAll('iframe').forEach((frame) => {
+        try {
+          if (frame.contentDocument) {
+            addStyle(frame.contentDocument);
+            frame.style.height = '100%';
+          }
+        } catch (_) {
+          // ignore cross-origin iframes
+        }
+      });
     })();`;
     webview.executeJavaScript(js);
   }


### PR DESCRIPTION
## Summary
- expand `highlightImages` agent to apply styles inside iframes
- add iframe fixture for tests
- test highlighting for both document and iframe
- bump version to 1.0.2

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68465dd8ed908325affea2646c1c6211